### PR TITLE
adds service binding to oarec

### DIFF
--- a/python/plugins/MetaSearch/dialogs/maindialog.py
+++ b/python/plugins/MetaSearch/dialogs/maindialog.py
@@ -551,11 +551,10 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
             return
 
         # if the record has a bbox, show a footprint on the map
-        # this is the 'proper' coord order of the box returned by owslib
         if record['bbox'] is not None:
             bx = record['bbox']
-            rt = QgsRectangle(float(bx['minx']), float(bx['maxx']),
-                              float(bx['miny']), float(bx['maxy']))
+            rt = QgsRectangle(float(bx['minx']), float(bx['miny']),
+                              float(bx['maxx']), float(bx['maxy']))
             geom = QgsGeometry.fromRect(rt)
             
             if geom is not None:

--- a/python/plugins/MetaSearch/dialogs/maindialog.py
+++ b/python/plugins/MetaSearch/dialogs/maindialog.py
@@ -551,11 +551,13 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
             return
 
         # if the record has a bbox, show a footprint on the map
+        # this is the 'proper' coord order of the box returned by owslib
         if record['bbox'] is not None:
             bx = record['bbox']
-            rt = QgsRectangle(float(bx['minx']), float(bx['miny']),
-                              float(bx['maxx']), float(bx['maxy']))
+            rt = QgsRectangle(float(bx['minx']), float(bx['maxx']),
+                              float(bx['miny']), float(bx['maxy']))
             geom = QgsGeometry.fromRect(rt)
+            
             if geom is not None:
                 src = QgsCoordinateReferenceSystem("EPSG:4326")
                 dst = self.map.mapSettings().destinationCrs()
@@ -579,7 +581,7 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
 
         services = {}
         for link in record['links']:
-
+            link = self.catalog.parse_link(link)
             if 'scheme' in link:
                 link_type = link['scheme']
             elif 'protocol' in link:
@@ -589,7 +591,7 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
 
             if link_type is not None:
                 link_type = link_type.upper()
-
+            
             wmswmst_link_types = list(
                 map(str.upper, link_types.WMSWMST_LINK_TYPES))
             wfs_link_types = list(map(str.upper, link_types.WFS_LINK_TYPES))

--- a/python/plugins/MetaSearch/resources/templates/record_metadata_oarec.html
+++ b/python/plugins/MetaSearch/resources/templates/record_metadata_oarec.html
@@ -1,4 +1,26 @@
 <!DOCTYPE html>
+{% macro render_item_value(v, width) -%}
+    {% set val = v | string | trim %}
+    {% if val|length and val.lower().endswith(('.jpg', '.jpeg', '.png', '.gif', '.bmp')) %}
+        {# Ends with image extension: render img element with link to image #}
+        <a href="{{ val }}"><img src="{{ val }}" alt="{{ val.split('/') | last }}" width="{{ width }}"/></a>
+    {% elif v is string or v is number %}
+        {{ val | urlize() }}
+    {% elif v is mapping %}
+        <ul>
+      {% for i,j in v.items() %}
+        <li><i>{{ gettext(i) }}:</i> {{ render_item_value(j, 60) }}</li>
+      {% endfor %}</ul>
+    {% elif v is iterable %}
+        <ul>
+      {% for i in v %}
+        <li>{{ render_item_value(i, 60) }}</li>
+      {% endfor %}
+        </ul>
+    {% else %}
+      {{ val | urlize() }}
+    {% endif %}
+{%- endmacro %}
 <html lang="{{ language }}">
     <head>
         <meta charset="utf-8"/>
@@ -22,18 +44,19 @@
         <section id="record-metadata">
             <table>
                 <tr>
-                    <td>Identifier</td>
+                    <td>gettext('Identifier')</td>
                     <td>{{ obj['id'] }}</td>
                 </tr>
+                {% if (obj['properties']) %}
                 {% for a,b in obj['properties'].items() %}
                     {% if a not in ['extent'] %}
                         <tr>
-                            <td>{{ a }}</td>
-                            <td>{{ b }}</td>
+                            <td>{{ gettext(a) }}</td>
+                            <td>{{ render_item_value( b, 120 ) }}</td>
                         </tr>
                   {% endif %}
                 {% endfor %}
-
+                {% endif %}
             </table>
         </section>
     </body>

--- a/python/plugins/MetaSearch/search_backend.py
+++ b/python/plugins/MetaSearch/search_backend.py
@@ -259,8 +259,8 @@ def bbox_list_to_dict(bbox):
     if isinstance(bbox, list):
         dict_ = {
             'minx': bbox[0],
-            'maxx': bbox[1],
-            'miny': bbox[2],
+            'maxx': bbox[2],
+            'miny': bbox[1],
             'maxy': bbox[3]
         }
     else:

--- a/python/plugins/MetaSearch/search_backend.py
+++ b/python/plugins/MetaSearch/search_backend.py
@@ -143,6 +143,9 @@ class CSW202Search(SearchBase):
 
         return self.conn.records[identifier]
 
+    def parse_link(self, link):
+        return link    
+
 
 class OARecSearch(SearchBase):
     def __init__(self, url, timeout, auth):
@@ -219,7 +222,7 @@ class OARecSearch(SearchBase):
                 'type': rec['properties']['type'],
                 'bbox': None,
                 'title': rec['properties']['title'],
-                'links': rec['properties'].get('links', [])
+                'links': rec['properties'].get('associations', [])
             }
             try:
                 bbox2 = rec['properties']['extent']['spatial']['bbox'][0][0]
@@ -232,6 +235,17 @@ class OARecSearch(SearchBase):
 
         return recs
 
+    def parse_link(self, link):
+        link2 = {}
+        if 'href' in link:
+            link2['url'] = link['href']
+        if 'type' in link:
+            link2['protocol'] = link['type']
+        if 'title' in link:
+            link2['title'] = link['title']
+        if 'id' in link:
+            link2['name'] = link['id']
+        return link2  
 
 def get_catalog_service(url, catalog_type, timeout, username, password, auth):
     if catalog_type in [None, CATALOG_TYPES[0]]:


### PR DESCRIPTION
fixes boundingbox
improvements metadata template

This uses an approach which fits with the pygeoapi demo dataset (dutch-metadata), it uses link@type="ogc:wms" to indicate the servicetype. This does probably not match with what will be decided in the ogc api records group, so we need to change this as soon as the discussion on this topic settles